### PR TITLE
Update dependency version for alleyinteractive/wp-bulk-task to ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   "require": {
     "php": "^8.2",
     "alleyinteractive/composer-wordpress-autoloader": "^1.0",
-    "alleyinteractive/wp-bulk-task": "^0.2",
+    "alleyinteractive/wp-bulk-task": "^1.0",
     "alleyinteractive/wp-match-blocks": "^3.0",
     "alleyinteractive/wp-type-extensions": "^2.1"
   },


### PR DESCRIPTION
As titled. Tests are passing after the update.