### PR TITLE
issue-9: Upgrade WP Type Extensions package to ^3.0

### DIFF
--- a/.github/workflows/all-pr-tests.yml
+++ b/.github/workflows/all-pr-tests.yml
@@ -17,7 +17,7 @@ jobs:
     # Define a matrix of PHP/WordPress versions to test against
     strategy:
       matrix:
-        php: [8.2, 8.3]
+        php: [8.2, 8.3, 8.4]
         wordpress: ["latest"]
         multisite: [false]
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This library adheres to [Semantic Versioning](https://semver.org/) and [Keep a C
 
 Nothing yet.
 
+## 2.0.2
+
+### Changed
+
+- Updated package `alleyinteractive/wp-type-extensions` to ^3.0.
+- Removed non-existent `@phpunit` script from `composer.json`.
+- CI: Added PHP 8.4 to the test matrix.
+
 ## 2.0.1
 
 - Updated the minimum version of `wp-bulk-task` to ^1.0.

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "alleyinteractive/composer-wordpress-autoloader": "^1.0",
     "alleyinteractive/wp-bulk-task": "^1.0",
     "alleyinteractive/wp-match-blocks": "^3.0",
-    "alleyinteractive/wp-type-extensions": "^2.1"
+    "alleyinteractive/wp-type-extensions": "^3.0"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^2.0",
@@ -66,8 +66,7 @@
     "phpstan": "phpstan -v --memory-limit=512M",
     "test": [
       "@phpcs",
-      "@phpstan",
-      "@phpunit"
+      "@phpstan"
     ],
     "tidy": "[ $COMPOSER_DEV_MODE -eq 0 ] || composer normalize"
   }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "alleyinteractive/composer-wordpress-autoloader": "^1.0",
     "alleyinteractive/wp-bulk-task": "^1.0",
     "alleyinteractive/wp-match-blocks": "^3.0",
-    "alleyinteractive/wp-type-extensions": "^3.0"
+    "alleyinteractive/wp-type-extensions": "^2.1|^3.0"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^2.0",


### PR DESCRIPTION
fixes #9 

- Upgraded WP Type Extensions package to version ^3.0.
- Implemented miscellaneous changes.